### PR TITLE
Fix expense edit modal state

### DIFF
--- a/src/components/expense-drawer.jsx
+++ b/src/components/expense-drawer.jsx
@@ -66,15 +66,27 @@ export default function ExpenseDrawer({
   )
 
   useEffect(() => {
-    setIncome(selectedExpense.income)
-    setName(selectedExpense.name)
-    setAmount(selectedExpense.amount)
-    setDate(new Date(`${selectedExpense.date}T00:00:00`))
-    setCategory(selectedExpense.category)
-    setPaidBy(selectedExpense.paidBy)
-    setSplitBetween(selectedExpense.splitBetween)
-    setCurrency(selectedExpense.currency || defaultCurrency)
-  }, [selectedExpense, defaultCurrency])
+    if (isDrawerOpen) {
+      setIncome(selectedExpense.income)
+      setName(selectedExpense.name)
+      setAmount(selectedExpense.amount)
+      setDate(new Date(`${selectedExpense.date}T00:00:00`))
+      setCategory(selectedExpense.category)
+      setPaidBy(selectedExpense.paidBy)
+      setSplitBetween(selectedExpense.splitBetween)
+      setCurrency(selectedExpense.currency || defaultCurrency)
+    } else {
+      // Reset form state when drawer closes
+      setIncome(false)
+      setName("")
+      setAmount("")
+      setDate(new Date())
+      setCategory("")
+      setPaidBy([])
+      setSplitBetween([])
+      setCurrency(defaultCurrency)
+    }
+  }, [selectedExpense, defaultCurrency, isDrawerOpen])
 
   const confettiExplosion = () => {
     const shoot = () => {

--- a/src/components/expense-drawer.jsx
+++ b/src/components/expense-drawer.jsx
@@ -66,27 +66,15 @@ export default function ExpenseDrawer({
   )
 
   useEffect(() => {
-    if (isDrawerOpen) {
-      setIncome(selectedExpense.income)
-      setName(selectedExpense.name)
-      setAmount(selectedExpense.amount)
-      setDate(new Date(`${selectedExpense.date}T00:00:00`))
-      setCategory(selectedExpense.category)
-      setPaidBy(selectedExpense.paidBy)
-      setSplitBetween(selectedExpense.splitBetween)
-      setCurrency(selectedExpense.currency || defaultCurrency)
-    } else {
-      // Reset form state when drawer closes
-      setIncome(false)
-      setName("")
-      setAmount("")
-      setDate(new Date())
-      setCategory("")
-      setPaidBy([])
-      setSplitBetween([])
-      setCurrency(defaultCurrency)
-    }
-  }, [selectedExpense, defaultCurrency, isDrawerOpen])
+    setIncome(selectedExpense.income)
+    setName(selectedExpense.name)
+    setAmount(selectedExpense.amount)
+    setDate(new Date(`${selectedExpense.date}T00:00:00`))
+    setCategory(selectedExpense.category)
+    setPaidBy(selectedExpense.paidBy)
+    setSplitBetween(selectedExpense.splitBetween)
+    setCurrency(selectedExpense.currency || defaultCurrency)
+  }, [selectedExpense, defaultCurrency])
 
   const confettiExplosion = () => {
     const shoot = () => {

--- a/src/hooks/use-expense.js
+++ b/src/hooks/use-expense.js
@@ -51,6 +51,7 @@ const useExpense = (ledgerName) => {
 
   const closeExpenseDrawer = useCallback(() => {
     setIsDrawerOpen(false)
+    setSelectedExpense(emptyExpense)
   }, [])
 
   const closeDeleteDrawer = useCallback(() => {


### PR DESCRIPTION
# Fix Expense Edit Modal State Persistence

## Issue
When editing multiple expenses in succession, the "Paid By" field incorrectly shows data from the previously edited expense. This happens because the selected expense state wasn't being reset when the drawer closes.

## Changes
Modified the `closeExpenseDrawer` function in `useExpense` hook to reset the selected expense state when the drawer closes:
```javascript
const closeExpenseDrawer = useCallback(() => {
  setIsDrawerOpen(false)
  setSelectedExpense(emptyExpense)  // Reset selected expense when drawer closes
}, [])
```

## Why This Approach?
1. **Single Responsibility**: The `useExpense` hook is the source of truth for expense state management
2. **Predictable State**: When the drawer closes, we explicitly reset the selected expense
3. **Clean Data Flow**: State changes flow from parent (hook) to child (drawer) in a clear way
4. **Simple Solution**: No need for complex conditional logic in the drawer component

## Testing Done
- Verified that opening a new expense shows empty fields
- Verified that editing an existing expense shows correct data
- Verified that closing and reopening the modal shows correct data for each expense
- Verified that editing multiple expenses in succession shows correct data for each expense


I tested and it works
