### PR TITLE
[XPN-112] Fix chart currency conversion

### DIFF
--- a/src/components/expense-chart-drawer.tsx
+++ b/src/components/expense-chart-drawer.tsx
@@ -26,6 +26,7 @@ interface Transaction {
     paid: number
     owes: number
   }>
+  displayAmount: number
 }
 
 interface TransactionMonth {
@@ -80,9 +81,16 @@ export function ExpenseChartDrawer({
             expense.expense_type === "expense" && !(expense.category || "").toLowerCase().includes("transfer")
         )
 
-        const totalExpenses = filteredExpenses.reduce((acc, transaction) => acc + transaction.amount, 0)
+        // Use displayAmount which is already converted to the ledger's base currency
+        const totalExpenses = filteredExpenses.reduce((acc, transaction) => {
+          // Use displayAmount which includes exchange rate conversion if available
+          return acc + transaction.displayAmount
+        }, 0)
 
-        return { month: monthYear, expenses: totalExpenses }
+        return { 
+          month: monthYear, 
+          expenses: totalExpenses
+        }
       })
       .filter(
         // Filter out months with no expenses

--- a/src/hooks/use-xpnz-api.js
+++ b/src/hooks/use-xpnz-api.js
@@ -25,12 +25,20 @@ export function useXpnzApi(ledger) {
   }
 
   const apiGetExpenses = async () => {
-    const response = await fetch(`${api.base}/transactions?ledger=${ledger}`, { cache: "no-store" })
+    // Fetch without useExchangeRates to preserve original currency amounts
+    const response = await fetch(`${api.base}/transactions?ledger=${ledger}`, { 
+      cache: "no-store",
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
     const expenses = await response.json()
     const expensesPlus = expenses.map((expense) => {
       return {
         ...expense,
         income: expense.expense_type === "income",
+        // For chart display, convert if exchange rate is available
+        displayAmount: expense.exchange_rate ? expense.amount * expense.exchange_rate : expense.amount,
         paidBy: expense.contributions
           .map((c) => ({
             member: c.member,


### PR DESCRIPTION
Fixes XPN-112

## Changes
- Fixed monthly summary chart to correctly show expenses in base currency (CAD)
- Use `displayAmount` (which includes exchange rate conversion) for monthly totals
- Removed redundant fields and simplified chart state
- Cleaned up unused data in the chart component

## Testing
- Tested end to end
<img width="319" alt="image" src="https://github.com/user-attachments/assets/b35845ce-dd30-4c71-a690-4f169ab46175" />


In future
Make it so we can update the currency and have the chart reflect that as well 