### PR TITLE
feat: Add success toast notifications for expense saves

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,7 +80,8 @@ function LedgerLayout() {
     isDeleteDrawerOpen,
     closeDeleteDrawer,
     onDeleteClick,
-    handleDelete
+    handleDelete,
+    savingExpenseId
   } = useExpense(ledgerName)
 
   const emptyMode = expenses.length === 0
@@ -117,7 +118,8 @@ function LedgerLayout() {
     showChart,
     toggleChart,
     enableChart,
-    setEnableChart
+    setEnableChart,
+    savingExpenseId
   }
 
   if (isLoading) return <div></div>

--- a/src/components/animated-card.jsx
+++ b/src/components/animated-card.jsx
@@ -9,7 +9,7 @@ import { useOutletContext } from "react-router-dom"
 import { currencySymbols, formatDigit } from "@/api/utilities.js"
 
 const AnimatedCard = memo(
-  ({ expense, showDetails, onCardClick, onEditClick, onDeleteClick, onCopyClick, className }) => {
+  ({ expense, showDetails, onCardClick, onEditClick, onDeleteClick, onCopyClick, className, savingExpenseId }) => {
     // Define animation variants for the card
     const cardVariants = {
       initial: { scale: 1 },
@@ -73,6 +73,8 @@ const AnimatedCard = memo(
       split: "bg-red-200 dark:bg-red-900"
     }
 
+    const isSaving = savingExpenseId === expense.id || (expense.id === "" && savingExpenseId === "new")
+
     return (
       <ContextMenu>
         <ContextMenuTrigger>
@@ -85,10 +87,11 @@ const AnimatedCard = memo(
             viewport={{ once: false, amount: 0 }}
           >
             <motion.div
-              className={
-                "flex flex-col overflow-hidden rounded-lg text-card-foreground h-full" +
-                (showDetails ? " bg-linear-foreground" : " bg-card")
-              }
+              className={cn(
+                "flex flex-col overflow-hidden rounded-lg text-card-foreground h-full",
+                showDetails ? " bg-linear-foreground" : " bg-card",
+                isSaving && "opacity-50 blur-sm"
+              )}
               layout
               variants={cardVariants}
               animate={showDetails ? "expanded" : "initial"}

--- a/src/components/expense-drawer.jsx
+++ b/src/components/expense-drawer.jsx
@@ -146,13 +146,34 @@ export default function ExpenseDrawer({
     })
 
     const dateString = date.toISOString().split("T")[0]
-    if (isEditMode) {
-      await editExpense(id, name, currency, category, dateString, income ? "income" : "expense", contributions)
-    } else {
-      await pushExpense(name, currency, category, dateString, income ? "income" : "expense", contributions)
-    }
+    
+    // Close drawer
     handleCloseDrawer()
-    confettiExplosion()
+
+    try {
+      // Let the API call happen in the background
+      if (isEditMode) {
+        await editExpense(id, name, currency, category, dateString, income ? "income" : "expense", contributions)
+        confettiExplosion()
+        toast({
+          title: "Updated!",
+          description: "Your expense has been updated successfully.",
+        })
+      } else {
+        await pushExpense(name, currency, category, dateString, income ? "income" : "expense", contributions)
+        confettiExplosion()
+        toast({
+          title: "Added!",
+          description: "Your expense has been added successfully.",
+        })
+      }
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to save expense. Please try again.",
+        variant: "destructive"
+      })
+    }
   }
 
   useEffect(() => {

--- a/src/components/expense-masonry.jsx
+++ b/src/components/expense-masonry.jsx
@@ -18,7 +18,8 @@ export default function ExpenseMasonryGrouped() {
     showChart,
     toggleChart,
     enableChart,
-    setEnableChart
+    setEnableChart,
+    savingExpenseId
   } = useOutletContext()
 
   const filteredGroups = useMemo(() => {
@@ -66,6 +67,7 @@ export default function ExpenseMasonryGrouped() {
               openEditExpenseDrawer={openEditExpenseDrawer}
               copyExpense={copyExpense}
               onDeleteClick={onDeleteClick}
+              savingExpenseId={savingExpenseId}
             />
           ))}
         </main>
@@ -75,7 +77,7 @@ export default function ExpenseMasonryGrouped() {
   )
 }
 
-function MonthGroup({ monthYear, expenses, openEditExpenseDrawer, copyExpense, onDeleteClick }) {
+function MonthGroup({ monthYear, expenses, openEditExpenseDrawer, copyExpense, onDeleteClick, savingExpenseId }) {
   const { expandAll, currencySymbol } = useOutletContext()
 
   const [isOpen, setIsOpen] = useState(true)
@@ -172,6 +174,7 @@ function MonthGroup({ monthYear, expenses, openEditExpenseDrawer, copyExpense, o
                   onDeleteClick={onDeleteClick}
                   showDetails={isCardOpen(expense.id)}
                   onCardClick={() => toggleCardState(expense.id)}
+                  savingExpenseId={savingExpenseId}
                 />
               ))}
             </Masonry>

--- a/src/components/single-expense-masonry.jsx
+++ b/src/components/single-expense-masonry.jsx
@@ -5,7 +5,7 @@ import AnimatedCard from "@/components/animated-card.jsx"
 import { Masonry } from "masonic"
 
 export default function ExpenseMasonry() {
-  const { searchTerm, expenses, openEditExpenseDrawer, onDeleteClick, copyExpense } = useOutletContext()
+  const { searchTerm, expenses, openEditExpenseDrawer, onDeleteClick, copyExpense, savingExpenseId } = useOutletContext()
 
   const [filteredExpenses, setFilteredExpenses] = useState([])
 
@@ -35,6 +35,7 @@ export default function ExpenseMasonry() {
       onEditClick={openEditExpenseDrawer}
       onCopyClick={copyExpense}
       onDeleteClick={onDeleteClick}
+      savingExpenseId={savingExpenseId}
     />
   )
 

--- a/src/hooks/use-expense.js
+++ b/src/hooks/use-expense.js
@@ -17,6 +17,7 @@ const useExpense = (ledgerName) => {
   const [selectedExpense, setSelectedExpense] = useState(emptyExpense)
   const [isDeleteDrawerOpen, setIsDeleteDrawerOpen] = useState(false)
   const [expenseToDelete, setExpenseToDelete] = useState(null)
+  const [savingExpenseId, setSavingExpenseId] = useState(null)
 
   const {
     balance,
@@ -28,14 +29,32 @@ const useExpense = (ledgerName) => {
     pushMember,
     editMember,
     deleteMember,
-    pushExpense,
-    editExpense,
+    pushExpense: apiPushExpense,
+    editExpense: apiEditExpense,
     deleteExpense,
     loaded
   } = useXpnzApi(ledgerName)
   const memberNames = members.map((member) => member.name)
 
   const setExpenses = () => {} // stub
+
+  const pushExpense = useCallback(async (name, currency, category, date, expense_type, contributions) => {
+    setSavingExpenseId("new")
+    try {
+      await apiPushExpense(name, currency, category, date, expense_type, contributions)
+    } finally {
+      setSavingExpenseId(null)
+    }
+  }, [apiPushExpense])
+
+  const editExpense = useCallback(async (id, name, currency, category, date, expense_type, contributions) => {
+    setSavingExpenseId(id)
+    try {
+      await apiEditExpense(id, name, currency, category, date, expense_type, contributions)
+    } finally {
+      setSavingExpenseId(null)
+    }
+  }, [apiEditExpense])
 
   const openAddExpenseDrawer = useCallback(() => {
     setIsDrawerOpen(true)
@@ -106,7 +125,8 @@ const useExpense = (ledgerName) => {
     isDeleteDrawerOpen,
     closeDeleteDrawer,
     onDeleteClick,
-    handleDelete
+    handleDelete,
+    savingExpenseId
   }
 }
 


### PR DESCRIPTION
as title. 

blurring hooks into create and update api call. If the state has a saving expense ID then the card will be blurred. If it's null then it will show.

Added a toast as well and moved confetti to fire only if the API was successful

Now the expense card will be blurred while it's being saved. Here's what happens:
When you click save in the drawer:

The drawer closes
The expense card being saved (or the new card if adding) will be blurred with 50% opacity
The API call happens in the background
When the API call completes:
The blur is removed
The confetti animation plays
The success toast appears

If there's an error:

The blur is removed
An error toast appears
No confetti animation